### PR TITLE
Fixing print statement and starting clients #8

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+.idea
+.DS_Store

--- a/elasticsearch-stress-test.py
+++ b/elasticsearch-stress-test.py
@@ -370,7 +370,8 @@ def main():
           "because we are waiting for current bulk operation to complete. \n".format(NUMBER_OF_SECONDS))
 
     # Run the clients!
-    map(lambda thread: thread.start(), clients)
+    for d in clients:
+        d.start()
 
     # Create and start the print stats thread
     stats_thread = Thread(target=print_stats_worker, args=[STARTED_TIMESTAMP])
@@ -383,7 +384,7 @@ def main():
                 c.join(timeout=0.1)
             except KeyboardInterrupt:
                 print("")
-                print "Ctrl-c received! Sending kill to threads..."
+                print("Ctrl-c received! Sending kill to threads...")
                 shutdown_event.set()
                 
                 # set loop flag true to get into loop


### PR DESCRIPTION
I attempted to use this tool today but ran into a few issues.

First was the following exception:

```
/usr/bin/python3.4 elasticsearch-stress-test.py  --es_address internal-radar-loa-elastics-V0IPG0MET5WO-523946241.us-west-2.elb.amazonaws.com --indices 25 --documents 5 --seconds 300 --not-green --clients 5 --number-of-shards 2 --number-of-replicas 1 --no-cleanup --stats-frequency 10
  File "elasticsearch-stress-test.py", line 388
    print "Ctrl-c received! Sending kill to threads..."
                                                      ^
SyntaxError: Missing parentheses in call to 'print'
```

After I fixed that I hit this following exception:

```
/usr/bin/python3.4 elasticsearch-stress-test.py  --es_address internal-radar-loa-elastics-V0IPG0MET5WO-523946241.us-west-2.elb.amazonaws.com --indices 25 --documents 5 --seconds 300 --not-green --clients 5 --number-of-shards 2 --number-of-replicas 1 --no-cleanup --stats-frequency 10

Starting initialization of internal-radar-loa-elastics-V0IPG0MET5WO-523946241.us-west-2.elb.amazonaws.com
Done!
Creating indices..
Generating documents and workers..
Done!
Starting the test. Will print stats every 10 seconds.
The test would run for 300 seconds, but it might take a bit more because we are waiting for current bulk operation to complete.


Test is done! Final results:
Elapsed time: 4 seconds
Successful bulks: 0 (0 documents)
Failed bulks: 0 (0 documents)
Indexed approximately 0.0 MB which is 0.00 MB/s
```